### PR TITLE
Python support >= 3.8

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.9]
+        python-version: [3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Additional info about the build
@@ -67,7 +67,7 @@ jobs:
     env:
       CI_OS: ubuntu-latest
       PACKAGE: "ratar"
-      PYVER: "3.7"
+      PYVER: "3.8"
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -5,7 +5,7 @@ channels:
   - tpeulen
 dependencies:
   # Base depends
-  - python>=3.6
+  - python>=3.8
   - pip
   # Package depends
   - numpy


### PR DESCRIPTION
## Description
In line with other Volkamer Lab repositories, run CI von Python 3.8 and 3.9 (i.e. in this instance change Py 3.7 to 3.8 tests).
Update the environment file accordingly.

## Todos
  - [x] Update CI configs
  - [x] Update environment (currently >=3.6)

## Status
- [x] Ready to go