### PR TITLE
Fix bug: repeat similarity matrix

### DIFF
--- a/ratar/similarity.py
+++ b/ratar/similarity.py
@@ -100,7 +100,7 @@ def get_similarity_all_against_all(encoded_molecules_path, measure="modified_man
                 desc = f"{repres}_{dim}_{method}"
 
                 # Add initial all-against-all matrices in dictionary
-                sim_matrices[desc] = sim_df
+                sim_matrices[desc] = sim_df.copy()
 
     # Load all possible binding site pairs (to construct an upper triangular matrix)
     for path1, path2 in itertools.combinations(path_list, r=2):


### PR DESCRIPTION
## Description
Fix bug: all the DataFrames of the output of `ratar.similarity. get_similarity_all_against_all()` are the same. Likely because if you use the same DataFrame object for all keys and then modify it, all keys will end up referencing the same DataFrame, thus appearing to have the same value.

## Status
- [ ] Ready to go